### PR TITLE
音声認識テキストのTXT保存機能を実装

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git checkout:*)"
+    ],
+    "deny": []
+  }
+}

--- a/js/domElements.js
+++ b/js/domElements.js
@@ -20,6 +20,7 @@ class DOMElements {
         this.elements.retryButton = document.getElementById('retryButton');
         this.elements.clearButton = document.getElementById('clearButton');
         this.elements.saveHistoryButton = document.getElementById('saveHistoryButton');
+        this.elements.saveTxt = document.getElementById('saveTxt');
 
         // 結果表示エリア
         this.elements.resultTextElement = document.getElementById('resultText');

--- a/js/main.js
+++ b/js/main.js
@@ -190,6 +190,12 @@ class WebSpeechApp {
             saveHistoryButton.addEventListener('click', () => this.handleSaveToHistory());
         }
         
+        // TXT保存ボタン
+        const saveTxtButton = this.domElements.get('saveTxt');
+        if (saveTxtButton) {
+            saveTxtButton.addEventListener('click', () => this.handleSaveTxt());
+        }
+        
         // 読み上げボタン
         const speakAllButton = this.domElements.get('speakAllButton');
         const speakNewButton = this.domElements.get('speakNewButton');
@@ -313,6 +319,59 @@ class WebSpeechApp {
         } else {
             this.uiManager.showStatus('ステータス: 保存するテキストがありません', 'info');
         }
+    }
+
+    handleSaveTxt() {
+        // 現在のテキストとひらがなを取得
+        const currentText = this.domElements.get('resultTextElement').textContent.trim();
+        const currentHiragana = this.domElements.get('hiraganaTextElement').textContent.trim();
+        
+        // プレースホルダーテキストは保存しない
+        const cleanCurrentText = currentText === 'ここに認識されたテキストが表示されます...' ? '' : currentText;
+        const cleanCurrentHiragana = currentHiragana === 'ここにひらがなで表示されます...' ? '' : currentHiragana;
+        
+        if (!cleanCurrentText) {
+            this.uiManager.showStatus('ステータス: 保存するテキストがありません', 'info');
+            return;
+        }
+        
+        // TXTファイルの内容を作成
+        let txtContent = '';
+        
+        if (cleanCurrentText) {
+            txtContent += '原文\n';
+            txtContent += cleanCurrentText + '\n';
+        }
+        
+        if (cleanCurrentHiragana) {
+            txtContent += 'ひらがな\n';
+            txtContent += cleanCurrentHiragana + '\n';
+        }
+        
+        // ファイル名を生成（日時ベース）
+        const now = new Date();
+        const dateStr = now.toISOString().slice(0, 19).replace(/[T:]/g, '-');
+        const fileName = `speech-text-${dateStr}.txt`;
+        
+        // ダウンロード処理
+        const blob = new Blob([txtContent], { type: 'text/plain; charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = fileName;
+        a.style.display = 'none';
+        
+        document.body.appendChild(a);
+        a.click();
+        
+        // クリーンアップ
+        setTimeout(() => {
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        }, 100);
+        
+        console.log('Speech text saved as TXT file:', fileName);
+        this.uiManager.showStatus('ステータス: TXTファイルを保存しました', 'success');
     }
 
     handleSpeakAll() {


### PR DESCRIPTION
- main.jsにhandleSaveTxt()メソッドを追加
- historyのdownloadTxt()実装を参考にしたファイル保存機能
- UTF-8エンコーディングで原文とひらがなを構造化して保存
- 既存のTXT保存ボタンにイベントリスナーを接続
- domElements.jsにsaveTxtボタンの要素定義を追加

🤖 Generated with [Claude Code](https://claude.ai/code)